### PR TITLE
Show context info along with progress

### DIFF
--- a/ooniprobe/Base.lproj/Main.storyboard
+++ b/ooniprobe/Base.lproj/Main.storyboard
@@ -128,20 +128,20 @@
         <scene sceneID="n9F-Ud-ZKt">
             <objects>
                 <tableViewController id="RZH-Z4-d2a" customClass="RunTestsViewController" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="60" sectionHeaderHeight="28" sectionFooterHeight="28" id="44p-sf-aNf">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="70" sectionHeaderHeight="28" sectionFooterHeight="28" id="44p-sf-aNf">
                         <rect key="frame" x="0.0" y="64" width="320" height="504"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.94901960780000005" alpha="1" colorSpace="calibratedRGB"/>
                         <prototypes>
-                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" shouldIndentWhileEditing="NO" reuseIdentifier="Cell_test" id="NOz-xh-E1j">
-                                <rect key="frame" x="0.0" y="28" width="320" height="60"/>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="0.0" shouldIndentWhileEditing="NO" reuseIdentifier="Cell_test" rowHeight="70" id="NOz-xh-E1j">
+                                <rect key="frame" x="0.0" y="28" width="320" height="70"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="NOz-xh-E1j" id="Xxv-Xf-Lev">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="69.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="version 0.1" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2SC-VG-VFl">
-                                            <rect key="frame" x="40" y="32" width="204" height="16"/>
+                                            <rect key="frame" x="40" y="42.5" width="204" height="16"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="16" id="imZ-59-9UV"/>
                                             </constraints>
@@ -187,7 +187,7 @@
                                             </constraints>
                                         </imageView>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Web Connectivity" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W4F-zK-60C">
-                                            <rect key="frame" x="40" y="8" width="204" height="18"/>
+                                            <rect key="frame" x="40" y="8" width="204" height="28.5"/>
                                             <fontDescription key="fontDescription" name="FiraSansOT-Bold" family="Fira Sans OT" pointSize="15"/>
                                             <color key="textColor" red="0.019607843140000001" green="0.53333333329999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -234,7 +234,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ycm-c3-ths" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="821" y="254"/>
+            <point key="canvasLocation" x="819.375" y="253.52112676056339"/>
         </scene>
         <!--Settings-->
         <scene sceneID="fBl-jm-kgo">
@@ -249,18 +249,18 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Ys4-cd-IGz" id="SPI-Ng-m2G">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Xz6-Gr-pNf">
-                                            <rect key="frame" x="15" y="7" width="31" height="24"/>
+                                            <rect key="frame" x="15" y="8" width="31" height="23.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" name="FiraSansOT-Bold" family="Fira Sans OT" pointSize="15"/>
                                             <color key="textColor" red="0.019607843140000001" green="0.53333333329999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Detail" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wnX-3b-3ez">
-                                            <rect key="frame" x="15" y="31" width="36" height="21"/>
+                                            <rect key="frame" x="15" y="31.5" width="35.5" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <fontDescription key="fontDescription" name="FiraSansOTMedium" family="Fira Sans OT" pointSize="13"/>
                                             <color key="textColor" red="0.46666666670000001" green="0.46666666670000001" blue="0.46666666670000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -275,11 +275,11 @@
                                 <rect key="frame" x="0.0" y="88" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="x2U-jv-ehv" id="MNd-YU-feK">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="59.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="r9o-lt-aY8">
-                                            <rect key="frame" x="15" y="0.0" width="290" height="59"/>
+                                            <rect key="frame" x="15" y="0.0" width="290" height="59.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" name="FiraSansOT-Bold" family="Fira Sans OT" pointSize="15"/>
                                             <color key="textColor" red="0.019607843140000001" green="0.53333333329999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -294,7 +294,7 @@
                                 <rect key="frame" x="0.0" y="148" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="poE-nt-GeH" id="MES-dj-SGf">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="1" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y97-cR-iIY">
@@ -482,7 +482,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Nz7-PK-UIn" id="uVX-Ks-Arq">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" tag="2" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="version 0.1" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PKZ-5R-npa">
@@ -576,7 +576,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="j9b-VZ-7Ks" id="mH3-vo-WBU">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" tag="1" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wh3-zx-upN">
@@ -920,11 +920,11 @@
                                         <rect key="frame" x="0.0" y="128" width="320" height="80"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="E6h-NL-Fs0" id="vlU-cc-ntl">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="79"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="79.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="LUr-7x-efz">
-                                                    <rect key="frame" x="15" y="0.0" width="290" height="79"/>
+                                                    <rect key="frame" x="15" y="0.0" width="290" height="79.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" name="FiraSansOT-Bold" family="Fira Sans OT" pointSize="15"/>
                                                     <color key="textColor" red="0.019607843140000001" green="0.53333333329999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1136,10 +1136,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l9F-w3-n0g" userLabel="contentView">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="257"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="228"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Understand the Laws" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jCF-8u-pXl">
-                                                <rect key="frame" x="16" y="0.0" width="288" height="118"/>
+                                                <rect key="frame" x="16" y="0.0" width="288" height="89"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="59" id="i5e-3P-dbM"/>
                                                 </constraints>
@@ -1148,7 +1148,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Laws text" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="1lY-p0-S2W">
-                                                <rect key="frame" x="16" y="126" width="288" height="28"/>
+                                                <rect key="frame" x="16" y="97" width="288" height="28"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="28" id="i1C-4t-FrS"/>
                                                 </constraints>
@@ -1157,7 +1157,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MDl-BL-HvH" customClass="RoundedButton">
-                                                <rect key="frame" x="90" y="194" width="140" height="55"/>
+                                                <rect key="frame" x="92.5" y="165" width="135" height="55"/>
                                                 <color key="backgroundColor" red="0.019607843140000001" green="0.53333333329999999" blue="0.79607843140000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="55" id="Esa-fR-3tB"/>
@@ -1171,7 +1171,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qVk-UF-3ih">
-                                                <rect key="frame" x="117" y="162" width="87" height="24"/>
+                                                <rect key="frame" x="117" y="133" width="87" height="24"/>
                                                 <color key="backgroundColor" red="0.94901960780000005" green="0.94901960780000005" blue="0.94901960780000005" alpha="1" colorSpace="calibratedRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="24" id="DBJ-f2-NyF"/>

--- a/ooniprobe/Model/NetworkMeasurement.h
+++ b/ooniprobe/Model/NetworkMeasurement.h
@@ -22,6 +22,7 @@
 
 @property NSNumber *test_id;
 @property float progress;
+@property NSString *progress_text;
 
 @property NSString *json_file;
 @property NSString *log_file;

--- a/ooniprobe/Model/NetworkMeasurement.mm
+++ b/ooniprobe/Model/NetworkMeasurement.mm
@@ -115,8 +115,9 @@ static std::string get_dns_server() {
     return fileName;
 }
 
--(void)updateProgress:(double)prog {
+-(void)updateProgress:(double)prog description:(NSString *)text {
     self.progress = prog;
+    self.progress_text = text;
 #ifdef DEBUG
     NSString *os = [NSString stringWithFormat:@"Progress: %.1f%%", prog * 100.0];
     NSLog(@"%@", os);
@@ -245,7 +246,8 @@ static std::string get_dns_server() {
         .set_error_filepath([[self getFileName:@"log"] UTF8String])
         .set_verbosity(MK_LOG_INFO)
         .on_progress([self](double prog, const char *s) {
-            [self updateProgress:prog];
+            [self updateProgress:prog
+                     description:[NSString stringWithFormat:@"%s", s]];
         })
         .on_log([self](uint32_t type, const char *s) {
             #ifdef DEBUG
@@ -295,7 +297,8 @@ static std::string get_dns_server() {
         .set_error_filepath([[self getFileName:@"log"] UTF8String])
         .set_verbosity(MK_LOG_INFO)
         .on_progress([self](double prog, const char *s) {
-            [self updateProgress:prog];
+            [self updateProgress:prog
+                     description:[NSString stringWithFormat:@"%s", s]];
         })
         .on_log([self](uint32_t type, const char *s) {
             #ifdef DEBUG
@@ -351,7 +354,8 @@ static std::string get_dns_server() {
         .set_output_filepath([[self getFileName:@"json"] UTF8String])
         .set_verbosity(MK_LOG_INFO)
         .on_progress([self](double prog, const char *s) {
-            [self updateProgress:prog];
+            [self updateProgress:prog
+                     description:[NSString stringWithFormat:@"%s", s]];
         })
         .on_log([self](uint32_t type, const char *s) {
             #ifdef DEBUG
@@ -411,7 +415,8 @@ static std::string get_dns_server() {
         .set_output_filepath([[self getFileName:@"json"] UTF8String])
         .set_verbosity(MK_LOG_INFO)
         .on_progress([self](double prog, const char *s) {
-            [self updateProgress:prog];
+            [self updateProgress:prog
+                     description:[NSString stringWithFormat:@"%s", s]];
         })
         .on_log([self](uint32_t type, const char *s) {
             #ifdef DEBUG
@@ -463,7 +468,8 @@ static std::string get_dns_server() {
         .set_output_filepath([[self getFileName:@"json"] UTF8String])
         .set_error_filepath([[self getFileName:@"log"] UTF8String])
         .on_progress([self](double prog, const char *s) {
-            [self updateProgress:prog];
+            [self updateProgress:prog
+                     description:[NSString stringWithFormat:@"%s", s]];
         })
         .on_log([self](uint32_t type, const char *s) {
             #ifdef DEBUG

--- a/ooniprobe/View/RunTestsViewController.mm
+++ b/ooniprobe/View/RunTestsViewController.mm
@@ -100,14 +100,12 @@
     if (current.running){
         [bar setHidden:NO];
         [bar setProgress:current.progress animated:NO];
-        [subtitle setHidden:YES];
+        [subtitle setText:current.progress_text];
         [indicator setHidden:FALSE];
         [runTest setHidden:TRUE];
         [indicator startAnimating];
     }
     else {
-        [bar setHidden:YES];
-        [subtitle setHidden:NO];
         [indicator setHidden:TRUE];
         [runTest setHidden:FALSE];
         [indicator stopAnimating];


### PR DESCRIPTION
The ideal progress bar should never stutter. Probably, a real progress bar sometimes does because some operations (e.g. connecting to a host) are atomic and they may stall.

I think that printing what the app is doing below/above the progress bar reduces stuttering-induced anxiety, especially if possibly long operations are marked as such, for example:

> submitting results; please be patient...

Additionally, printing what the app does leads to continuous user awareness. One may be aware after reading the intro and then forget. More difficult to forget, if you see messages like:

> testing http://controversial.com for censorship

I think this (i.e. provide a small looking glass to users) is a desirable property.

I am wondering whether doing that makes the design less neat (I do really like it!): iOS does not add text to the progress bar, but Ubuntu (that I think is also quite pretty) does.

![install_ubuntu_10_04_from_usb_stick](https://cloud.githubusercontent.com/assets/337298/22662569/cb34734a-eca9-11e6-9564-7fe064fe830a.jpg)

This pull request implements what I'm proposing, in a ghetto way, to show it's possible:

![simulator screen shot 6 feb 2017 15 21 08](https://cloud.githubusercontent.com/assets/337298/22650736/c7b33fe0-ec80-11e6-913d-518f3d9060e7.png)

Thanks to @lorenzoPrimi who helped me to understand what was the best and quickest way to implement this change :-). If there's consensus, we can work on making it pretty!