### PR TITLE
Correct the spelling of CocoaPods in a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Download it on the [App Store](https://itunes.apple.com/us/app/id1199566366).
 
 If you are interested in building the app yourself, read on.
 
-To download and install the measurement-kit library we use [cocoapod](https://cocoapods.org).
+To download and install the measurement-kit library we use [CocoaPods](https://cocoapods.org).
 
 To install cocoapod use
 


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
