### PR TITLE
Updates README Image Header Redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![ooniprobe iOS](assets/title.png)
+[![ooniprobe iOS](assets/title.png)](https://ooni.torproject.org/)
 
 [![Slack Channel](https://slack.openobservatory.org/badge.svg)](https://slack.openobservatory.org/)
 


### PR DESCRIPTION
The README's image header redirect to the actual picture, it now redirects to the OONI site.