### PR TITLE
hotfix(VersionUtility): do not include build number

### DIFF
--- a/ooniprobe/Utility/VersionUtility.mm
+++ b/ooniprobe/Utility/VersionUtility.mm
@@ -11,6 +11,13 @@
 @implementation VersionUtility
 
 + (NSString*)get_software_version{
+    // FIXME: this breaks OONI backend so we don't send the build number
+    /*
     return [NSString stringWithFormat:@"%@%@+%@", [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"], release_name, [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"]];
+     */
+    return [NSString stringWithFormat:@"%@%@",
+            [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"],
+            release_name];
+
 }
 @end


### PR DESCRIPTION
This breaks OONI Backend.

See TheTorProject/ooni-backend#111 and TheTorProject/ooni-sysadmin#164.